### PR TITLE
Fix curl sample to work on macOS

### DIFF
--- a/observability/README.md
+++ b/observability/README.md
@@ -100,7 +100,7 @@ name: Curl validate
 
 
 ```bash
-curl -s http://localhost:9411/api/v2/traces?spanName=calllocal%2Fhello-tracing%2Fneworder -H  accept:application/json -o output.json && python -m json.tool output.json
+curl -s "http://localhost:9411/api/v2/traces?spanName=calllocal%2Fhello-tracing%2Fneworder" -H "accept:application/json" -o output.json && python -m json.tool output.json
 ```
 <!-- END_STEP -->
 


### PR DESCRIPTION
Signed-off-by: Marcin Jahn <marcinj10@gmail.com>

# Description

Adjusts the curl command to work on macOS

## Issue reference

#542

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
